### PR TITLE
Improve loading performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "start": "next start",
     "lint": "next lint"
   },
-  "browserslist": "defaults, not ie <= 11",
+  "browserslist": [
+    "defaults and supports es6-module",
+    "not ie <= 11"
+  ],
   "dependencies": {
     "@leafac/rehype-shiki": "^2.2.1",
     "@mdx-js/loader": "^2.3.0",

--- a/src/app/blog/wrapper.jsx
+++ b/src/app/blog/wrapper.jsx
@@ -5,6 +5,7 @@ import { MDXComponents } from '@/components/MDXComponents'
 import { PageLinks } from '@/components/PageLinks'
 import { formatDate } from '@/lib/formatDate'
 import { loadArticles } from '@/lib/mdx'
+import 'katex/dist/katex.min.css'
 
 export default async function BlogArticleWrapper({ article, children }) {
   let allArticles = await loadArticles()

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,7 +1,7 @@
 import { RootLayout } from '@/components/RootLayout'
+import Script from 'next/script'
 
 import '@/styles/tailwind.css'
-import 'katex/dist/katex.min.css'
 
 export const metadata = {
   metadataBase: new URL('https://grouplabs.ca'),
@@ -45,8 +45,10 @@ export default function Layout({ children }) {
     <html lang="en" className="h-full bg-neutral-950 text-base antialiased">
       <head>
         <link rel="icon" href="/favicon.ico" />
-        <script
+        <Script
+          id="organization-schema"
           type="application/ld+json"
+          strategy="afterInteractive"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify({
               '@context': 'https://schema.org',

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -3,7 +3,7 @@
 @font-face {
   font-family: 'Mona Sans';
   font-weight: 200 900;
-  font-display: block;
+  font-display: swap;
   font-style: normal;
   font-stretch: 75% 125%;
   src: url('../fonts/Mona-Sans.var.woff2') format('woff2');


### PR DESCRIPTION
## Summary
- avoid blocking rendering with fonts
- load math CSS only on blog articles
- load JSON-LD schema asynchronously
- target modern browsers for JS

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b44ba279c832cac189ff2efab21f0