### PR TITLE
Fix PageInsights issue by stripping console calls

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,9 @@ import { unifiedConditional } from 'unified-conditional'
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
+  compiler: {
+    removeConsole: process.env.NODE_ENV === 'production',
+  },
 }
 
 function remarkMDXLayout(source, metaName) {


### PR DESCRIPTION
## Summary
- configure Next.js to drop all console statements during production builds

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b4e36c30c832c8650ceed1f2a7291