### PR TITLE
Improve SEO by adding alt text for case study hero images

### DIFF
--- a/src/app/work/cenovus-energy/page.mdx
+++ b/src/app/work/cenovus-energy/page.mdx
@@ -10,7 +10,7 @@ export const caseStudy = {
     'We partnered with Cenovus Energy on a data-driven initiative to enhance decision making through data cleaning, modelling and training.'
   ],
   logo,
-  image: { src: imageHero },
+  image: { src: imageHero, alt: 'Cenovus Energy office' },
   date: '2024-01',
   service: 'Operational Analytics',
 }

--- a/src/app/work/hotchkiss-brain-institute/page.mdx
+++ b/src/app/work/hotchkiss-brain-institute/page.mdx
@@ -10,7 +10,7 @@ export const caseStudy = {
     'The project aimed to detect Alzheimer’s disease using hyperspectral imaging on blood samples. Techniques include MiniRocket algorithm, feature extraction, Gaussian smoothing, and MinMax scaling. The resulting architectures achieved over 98% accuracy.',
   ],
   logo,
-  image: { src: imageHero },
+  image: { src: imageHero, alt: 'Hotchkiss Brain Institute facility' },
   date: '2024-03',
   service: 'RNNs, LSTMs, XGBoost',
 }

--- a/src/app/work/smart-technologies/page.mdx
+++ b/src/app/work/smart-technologies/page.mdx
@@ -10,7 +10,7 @@ export const caseStudy = {
     'Using large language models, a Rust backend and a React/Next.js frontend, Elevate generates editable HTML/CSS/JS teaching resources on‑demand. Piloted in 5 schools across North America, the system produced 30+ activities and engaged more than 150 students while slashing teachers’ prep time.',
   ],
   logo,
-  image: { src: imageHero },
+  image: { src: imageHero, alt: 'SMART Technologies demo' },
   date: '2025-05',
   service: 'Scalable GenAI for Classrooms',
 }


### PR DESCRIPTION
## Summary
- improve accessibility & SEO by adding alt text to the hero image objects for each case study

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b883bc2cc832cb30fbacdc80a21d7