### PR TITLE
feat: show tags on blog posts

### DIFF
--- a/src/app/blog/AIs-impact-on-MRI-brain-lesion-detection/page.mdx
+++ b/src/app/blog/AIs-impact-on-MRI-brain-lesion-detection/page.mdx
@@ -10,6 +10,7 @@ export const article = {
     role: 'Scientist',
     image: { src: iamgeFiraollumar },
   },
+  tags: ['ai', 'medical imaging'],
 }
 
 export const metadata = {

--- a/src/app/blog/Diagnosing-diseases-with-voice/page.mdx
+++ b/src/app/blog/Diagnosing-diseases-with-voice/page.mdx
@@ -10,6 +10,7 @@ export const article = {
     role: 'Scientist',
     image: { src: iamgeFiraollumar },
   },
+  tags: ['ai', 'diagnostics', 'voice'],
 }
 
 export const metadata = {

--- a/src/app/blog/LoRA-Fine-Tuning-LLMs/page.mdx
+++ b/src/app/blog/LoRA-Fine-Tuning-LLMs/page.mdx
@@ -9,6 +9,7 @@ export const article = {
     role: 'AI Assistant',
     image: { src: chatgptLogo },
   },
+  tags: ['lora', 'fine-tuning', 'llm'],
 }
 
 export const metadata = {

--- a/src/app/blog/Pytorch-Internals/page.mdx
+++ b/src/app/blog/Pytorch-Internals/page.mdx
@@ -10,6 +10,7 @@ export const article = {
     role: 'Founder',
     image: { src: imageNoelThomas },
   },
+  tags: ['pytorch', 'deep learning'],
 }
 
 export const metadata = {

--- a/src/app/blog/Transformers/page.mdx
+++ b/src/app/blog/Transformers/page.mdx
@@ -10,6 +10,7 @@ export const article = {
     role: 'Founder',
     image: { src: imageNoelThomas },
   },
+  tags: ['transformers', 'deep learning'],
 }
 
 export const metadata = {

--- a/src/app/blog/Vector-Search-with-Embeddings/page.mdx
+++ b/src/app/blog/Vector-Search-with-Embeddings/page.mdx
@@ -9,6 +9,7 @@ export const article = {
     role: 'AI Assistant',
     image: { src: chatgptLogo },
   },
+  tags: ['rag', 'vector search', 'llm'],
 }
 
 export const metadata = {

--- a/src/app/blog/gRPC-and-libtorch-with-Bazel/page.mdx
+++ b/src/app/blog/gRPC-and-libtorch-with-Bazel/page.mdx
@@ -10,6 +10,7 @@ export const article = {
     role: 'Founder',
     image: { src: imageNoelThomas },
   },
+  tags: ['grpc', 'bazel', 'libtorch'],
 }
 
 export const metadata = {

--- a/src/app/blog/page.jsx
+++ b/src/app/blog/page.jsx
@@ -7,6 +7,7 @@ import { ContactSection } from '@/components/ContactSection'
 import { Container } from '@/components/Container'
 import { FadeIn } from '@/components/FadeIn'
 import { PageIntro } from '@/components/PageIntro'
+import { Badge } from '@/components/ui/badge'
 import { formatDate } from '@/lib/formatDate'
 import { loadArticles } from '@/lib/mdx'
 
@@ -66,6 +67,13 @@ export default async function Blog() {
                       <p className="mt-6 max-w-2xl text-base text-neutral-600">
                         {article.description}
                       </p>
+                      {article.tags?.length > 0 && (
+                        <div className="mt-4 flex flex-wrap gap-2">
+                          {article.tags.map((tag) => (
+                            <Badge key={tag}>{tag}</Badge>
+                          ))}
+                        </div>
+                      )}
                       <Button
                         href={article.href}
                         aria-label={`Read more: ${article.title}`}

--- a/src/app/blog/zsh-llm-config/page.mdx
+++ b/src/app/blog/zsh-llm-config/page.mdx
@@ -10,6 +10,7 @@ export const article = {
     role: 'Founder',
     image: { src: imageNoelThomas },
   },
+  tags: ['zsh', 'llm', 'shell'],
 }
 
 export const metadata = {

--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -1,0 +1,23 @@
+import clsx from 'clsx'
+
+const variants = {
+  default:
+    'border-transparent bg-neutral-950 text-neutral-50 hover:bg-neutral-950/80',
+  secondary:
+    'border-transparent bg-neutral-100 text-neutral-900 hover:bg-neutral-100/80',
+  outline: 'text-neutral-950',
+}
+
+export function Badge({ className, variant = 'default', ...props }) {
+  return (
+    <div
+      className={clsx(
+        'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2',
+        variants[variant],
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+

--- a/src/lib/mdx.js
+++ b/src/lib/mdx.js
@@ -19,8 +19,9 @@ async function loadEntries(directory, metaName) {
   ).sort((a, b) => b.date.localeCompare(a.date))
 }
 
-export function loadArticles() {
-  return loadEntries('blog', 'article')
+export async function loadArticles() {
+  let articles = await loadEntries('blog', 'article')
+  return articles.map((article) => ({ ...article, tags: article.tags || [] }))
 }
 
 export function loadCaseStudies() {


### PR DESCRIPTION
## Summary
- add tag arrays to each blog article
- include shadcn-style Badge component and display tags on blog index
- return tags from `loadArticles`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892e564f460832c80ab695d90cff221