### PR TITLE
feat: color-coded blog authors

### DIFF
--- a/src/app/blog/AIs-impact-on-MRI-brain-lesion-detection/page.mdx
+++ b/src/app/blog/AIs-impact-on-MRI-brain-lesion-detection/page.mdx
@@ -9,6 +9,7 @@ export const article = {
     name: 'Firaoll Umar',
     role: 'Scientist',
     image: { src: iamgeFiraollumar },
+    color: '#16a34a',
   },
 }
 

--- a/src/app/blog/Diagnosing-diseases-with-voice/page.mdx
+++ b/src/app/blog/Diagnosing-diseases-with-voice/page.mdx
@@ -9,6 +9,7 @@ export const article = {
     name: 'Firaoll Umar',
     role: 'Scientist',
     image: { src: iamgeFiraollumar },
+    color: '#16a34a',
   },
 }
 

--- a/src/app/blog/LoRA-Fine-Tuning-LLMs/page.mdx
+++ b/src/app/blog/LoRA-Fine-Tuning-LLMs/page.mdx
@@ -8,6 +8,8 @@ export const article = {
     name: 'ChatGPT',
     role: 'AI Assistant',
     image: { src: chatgptLogo },
+    color:
+      'linear-gradient(90deg, #10b981, #3b82f6, #8b5cf6)',
   },
 }
 

--- a/src/app/blog/Pytorch-Internals/page.mdx
+++ b/src/app/blog/Pytorch-Internals/page.mdx
@@ -9,6 +9,7 @@ export const article = {
     name: 'Noel Thomas',
     role: 'Founder',
     image: { src: imageNoelThomas },
+    color: '#2563eb',
   },
 }
 

--- a/src/app/blog/Transformers/page.mdx
+++ b/src/app/blog/Transformers/page.mdx
@@ -9,6 +9,7 @@ export const article = {
     name: 'Noel Thomas',
     role: 'Founder',
     image: { src: imageNoelThomas },
+    color: '#2563eb',
   },
 }
 

--- a/src/app/blog/Vector-Search-with-Embeddings/page.mdx
+++ b/src/app/blog/Vector-Search-with-Embeddings/page.mdx
@@ -8,6 +8,8 @@ export const article = {
     name: 'ChatGPT',
     role: 'AI Assistant',
     image: { src: chatgptLogo },
+    color:
+      'linear-gradient(90deg, #10b981, #3b82f6, #8b5cf6)',
   },
 }
 

--- a/src/app/blog/gRPC-and-libtorch-with-Bazel/page.mdx
+++ b/src/app/blog/gRPC-and-libtorch-with-Bazel/page.mdx
@@ -9,6 +9,7 @@ export const article = {
     name: 'Noel Thomas',
     role: 'Founder',
     image: { src: imageNoelThomas },
+    color: '#2563eb',
   },
 }
 

--- a/src/app/blog/page.jsx
+++ b/src/app/blog/page.jsx
@@ -30,55 +30,74 @@ export default async function Blog() {
 
       <Container className="mt-24 sm:mt-32 lg:mt-40">
         <div className="space-y-24 lg:space-y-32">
-          {articles.map((article) => (
-            <FadeIn key={article.href}>
-              <article>
-                <Border className="pt-16">
-                  <div className="relative lg:-mx-4 lg:flex lg:justify-end">
-                    <div className="pt-10 lg:w-2/3 lg:flex-none lg:px-4 lg:pt-0">
-                      <h2 className="font-display text-2xl font-semibold text-neutral-950">
-                        <Link href={article.href}>{article.title}</Link>
-                      </h2>
-                      <dl className="lg:absolute lg:left-0 lg:top-0 lg:w-1/3 lg:px-4">
-                        <dt className="sr-only">Published</dt>
-                        <dd className="absolute left-0 top-0 text-sm text-neutral-950 lg:static">
-                          <time dateTime={article.date}>
-                            {formatDate(article.date)}
-                          </time>
-                        </dd>
-                        <dt className="sr-only">Author</dt>
-                        <dd className="mt-6 flex gap-x-4">
-                          <div className="flex-none overflow-hidden rounded-xl bg-neutral-100">
-                            <Image
-                              alt={article.author.name}
-                              {...article.author.image}
-                              className="h-12 w-12 object-cover grayscale"
-                            />
-                          </div>
-                          <div className="text-sm text-neutral-950">
-                            <div className="font-semibold">
-                              {article.author.name}
+          {articles.map((article) => {
+            const isGradient = article.author.color?.startsWith(
+              'linear-gradient'
+            )
+            const imageStyle = isGradient
+              ? { background: article.author.color }
+              : { backgroundColor: article.author.color }
+            const textStyle = isGradient
+              ? {
+                  background: article.author.color,
+                  WebkitBackgroundClip: 'text',
+                  color: 'transparent',
+                }
+              : { color: article.author.color }
+
+            return (
+              <FadeIn key={article.href}>
+                <article>
+                  <Border className="pt-16">
+                    <div className="relative lg:-mx-4 lg:flex lg:justify-end">
+                      <div className="pt-10 lg:w-2/3 lg:flex-none lg:px-4 lg:pt-0">
+                        <h2 className="font-display text-2xl font-semibold text-neutral-950">
+                          <Link href={article.href}>{article.title}</Link>
+                        </h2>
+                        <dl className="lg:absolute lg:left-0 lg:top-0 lg:w-1/3 lg:px-4">
+                          <dt className="sr-only">Published</dt>
+                          <dd className="absolute left-0 top-0 text-sm text-neutral-950 lg:static">
+                            <time dateTime={article.date}>
+                              {formatDate(article.date)}
+                            </time>
+                          </dd>
+                          <dt className="sr-only">Author</dt>
+                          <dd className="mt-6 flex gap-x-4">
+                            <div
+                              className="flex-none rounded-xl p-0.5"
+                              style={imageStyle}
+                            >
+                              <Image
+                                alt={article.author.name}
+                                {...article.author.image}
+                                className="h-12 w-12 rounded-lg object-cover"
+                              />
                             </div>
-                            <div>{article.author.role}</div>
-                          </div>
-                        </dd>
-                      </dl>
-                      <p className="mt-6 max-w-2xl text-base text-neutral-600">
-                        {article.description}
-                      </p>
-                      <Button
-                        href={article.href}
-                        aria-label={`Read more: ${article.title}`}
-                        className="mt-8"
-                      >
-                        Read more
-                      </Button>
+                            <div className="text-sm" style={textStyle}>
+                              <div className="font-semibold">
+                                {article.author.name}
+                              </div>
+                              <div>{article.author.role}</div>
+                            </div>
+                          </dd>
+                        </dl>
+                        <p className="mt-6 max-w-2xl text-base text-neutral-600">
+                          {article.description}
+                        </p>
+                        <Button
+                          href={article.href}
+                          aria-label={`Read more: ${article.title}`}
+                          className="mt-8"
+                        >
+                          Read more
+                        </Button>
+                      </div>
                     </div>
-                  </div>
-                </Border>
-              </article>
-            </FadeIn>
-          ))}
+                  </Border>
+                </article>
+              </FadeIn>
+            )
+          })}
         </div>
       </Container>
 

--- a/src/app/blog/zsh-llm-config/page.mdx
+++ b/src/app/blog/zsh-llm-config/page.mdx
@@ -9,6 +9,7 @@ export const article = {
     name: 'Noel Thomas',
     role: 'Founder',
     image: { src: imageNoelThomas },
+    color: '#2563eb',
   },
 }
 


### PR DESCRIPTION
## Summary
- add colour metadata to all blog post authors, with ChatGPT sporting a vibrant gradient
- render author name and avatar using provided color on the blog index page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892e5679ba0832cb88533aef9340747