### PR TITLE
feat: decorate blog landing with grid backgrounds

### DIFF
--- a/src/app/blog/page.jsx
+++ b/src/app/blog/page.jsx
@@ -5,7 +5,8 @@ import { Border } from '@/components/Border'
 import { Button } from '@/components/Button'
 import { ContactSection } from '@/components/ContactSection'
 import { Container } from '@/components/Container'
-import { FadeIn } from '@/components/FadeIn'
+import { FadeIn, FadeInStagger } from '@/components/FadeIn'
+import { GridPattern } from '@/components/GridPattern'
 import { PageIntro } from '@/components/PageIntro'
 import { formatDate } from '@/lib/formatDate'
 import { loadArticles } from '@/lib/mdx'
@@ -17,8 +18,55 @@ export const metadata = {
   alternates: { canonical: '/blog' },
 }
 
+function Post({ article }) {
+  return (
+    <article>
+      <Border className="pt-16">
+        <div className="relative lg:-mx-4 lg:flex lg:justify-end">
+          <div className="pt-10 lg:w-2/3 lg:flex-none lg:px-4 lg:pt-0">
+            <h2 className="font-display text-2xl font-semibold text-neutral-950">
+              <Link href={article.href}>{article.title}</Link>
+            </h2>
+            <dl className="lg:absolute lg:left-0 lg:top-0 lg:w-1/3 lg:px-4">
+              <dt className="sr-only">Published</dt>
+              <dd className="absolute left-0 top-0 text-sm text-neutral-950 lg:static">
+                <time dateTime={article.date}>{formatDate(article.date)}</time>
+              </dd>
+              <dt className="sr-only">Author</dt>
+              <dd className="mt-6 flex gap-x-4">
+                <div className="flex-none overflow-hidden rounded-xl bg-neutral-100">
+                  <Image
+                    alt={article.author.name}
+                    {...article.author.image}
+                    className="h-12 w-12 object-cover grayscale"
+                  />
+                </div>
+                <div className="text-sm text-neutral-950">
+                  <div className="font-semibold">{article.author.name}</div>
+                  <div>{article.author.role}</div>
+                </div>
+              </dd>
+            </dl>
+            <p className="mt-6 max-w-2xl text-base text-neutral-600">
+              {article.description}
+            </p>
+            <Button
+              href={article.href}
+              aria-label={`Read more: ${article.title}`}
+              className="mt-8"
+            >
+              Read more
+            </Button>
+          </div>
+        </div>
+      </Border>
+    </article>
+  )
+}
+
 export default async function Blog() {
   let articles = await loadArticles()
+  let [latest, ...rest] = articles
 
   return (
     <>
@@ -28,58 +76,28 @@ export default async function Blog() {
         </p>
       </PageIntro>
 
-      <Container className="mt-24 sm:mt-32 lg:mt-40">
-        <div className="space-y-24 lg:space-y-32">
-          {articles.map((article) => (
+      <Container className="relative mt-24 sm:mt-32 lg:mt-40">
+        <GridPattern
+          className="absolute inset-x-0 top-0 -z-10 h-full w-full fill-neutral-100 stroke-neutral-950/5 [mask-image:linear-gradient(to_bottom_left,white,transparent)] sm:top-8"
+          yOffset={-96}
+        />
+        <FadeIn>
+          <Post article={latest} />
+        </FadeIn>
+      </Container>
+
+      <Container className="relative mt-24 sm:mt-32 lg:mt-40">
+        <GridPattern
+          className="absolute inset-0 -z-10 h-full w-full fill-neutral-100 stroke-neutral-950/5 [mask-image:linear-gradient(to_bottom_left,white_50%,transparent_70%)] sm:top-16"
+          yOffset={-128}
+        />
+        <FadeInStagger className="grid grid-cols-1 gap-x-8 gap-y-24 lg:grid-cols-2">
+          {rest.map((article) => (
             <FadeIn key={article.href}>
-              <article>
-                <Border className="pt-16">
-                  <div className="relative lg:-mx-4 lg:flex lg:justify-end">
-                    <div className="pt-10 lg:w-2/3 lg:flex-none lg:px-4 lg:pt-0">
-                      <h2 className="font-display text-2xl font-semibold text-neutral-950">
-                        <Link href={article.href}>{article.title}</Link>
-                      </h2>
-                      <dl className="lg:absolute lg:left-0 lg:top-0 lg:w-1/3 lg:px-4">
-                        <dt className="sr-only">Published</dt>
-                        <dd className="absolute left-0 top-0 text-sm text-neutral-950 lg:static">
-                          <time dateTime={article.date}>
-                            {formatDate(article.date)}
-                          </time>
-                        </dd>
-                        <dt className="sr-only">Author</dt>
-                        <dd className="mt-6 flex gap-x-4">
-                          <div className="flex-none overflow-hidden rounded-xl bg-neutral-100">
-                            <Image
-                              alt={article.author.name}
-                              {...article.author.image}
-                              className="h-12 w-12 object-cover grayscale"
-                            />
-                          </div>
-                          <div className="text-sm text-neutral-950">
-                            <div className="font-semibold">
-                              {article.author.name}
-                            </div>
-                            <div>{article.author.role}</div>
-                          </div>
-                        </dd>
-                      </dl>
-                      <p className="mt-6 max-w-2xl text-base text-neutral-600">
-                        {article.description}
-                      </p>
-                      <Button
-                        href={article.href}
-                        aria-label={`Read more: ${article.title}`}
-                        className="mt-8"
-                      >
-                        Read more
-                      </Button>
-                    </div>
-                  </div>
-                </Border>
-              </article>
+              <Post article={article} />
             </FadeIn>
           ))}
-        </div>
+        </FadeInStagger>
       </Container>
 
       <ContactSection />


### PR DESCRIPTION
## Summary
- refactor blog article rendering into `Post` component
- add grid pattern background to latest post hero
- surround post grid with responsive grid background

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892ebea828c832cbfdfbb5398f56f6f