### PR TITLE
fix: update about us company name

### DIFF
--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -141,10 +141,10 @@ export default async function About() {
         </p>
         <div className="mt-10 max-w-2xl space-y-6 text-base">
           <p>
-            Studio was started by two friends who noticed that machine learning
-            is still not accessible to everyone. Since the beginning, we have
-            been committed to doing things differently by building tools, and
-            expert networks to support the community.
+            GroupLabs was started by two friends who noticed that machine
+            learning is still not accessible to everyone. Since the beginning,
+            we have been committed to doing things differently by building
+            tools, and expert networks to support the community.
           </p>
         </div>
       </PageIntro>


### PR DESCRIPTION
## Summary
- change the about page wording to say GroupLabs was started by two friends

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8dff257f8832cafaa756c8c015d8d