### PR TITLE
feat: add compact header option

### DIFF
--- a/src/app/blog/BlogClient.jsx
+++ b/src/app/blog/BlogClient.jsx
@@ -79,13 +79,13 @@ export default function BlogClient({ articles }) {
 
   return (
     <>
-      <PageIntro eyebrow="Blog" title="What we're learning">
+      <PageIntro eyebrow="Blog" title="What we're learning" compact>
         <p>
           Stay up-to-date with our latest insights in computational research.
         </p>
       </PageIntro>
 
-      <Container className="relative mt-24 sm:mt-32 lg:mt-40">
+      <Container className="relative mt-8 sm:mt-12 lg:mt-16">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
           <input
             type="search"

--- a/src/components/PageIntro.jsx
+++ b/src/components/PageIntro.jsx
@@ -3,10 +3,19 @@ import clsx from 'clsx'
 import { Container } from '@/components/Container'
 import { FadeIn } from '@/components/FadeIn'
 
-export function PageIntro({ eyebrow, title, children, centered = false }) {
+export function PageIntro({
+  eyebrow,
+  title,
+  children,
+  centered = false,
+  compact = false,
+}) {
   return (
     <Container
-      className={clsx('mt-24 sm:mt-32 lg:mt-40', centered && 'text-center')}
+      className={clsx(
+        compact ? 'mt-12 sm:mt-16 lg:mt-20' : 'mt-24 sm:mt-32 lg:mt-40',
+        centered && 'text-center',
+      )}
     >
       <FadeIn>
         <h1>


### PR DESCRIPTION
## Summary
- add optional `compact` prop to `PageIntro` for tighter top spacing
- use compact `PageIntro` on blog and reduce spacing before search block

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e1e31ef4832cb20d0ed43e66f303