### PR TITLE
feat: display shadcn tags on blog posts

### DIFF
--- a/src/app/blog/BlogClient.jsx
+++ b/src/app/blog/BlogClient.jsx
@@ -12,6 +12,7 @@ import { FadeIn, FadeInStagger } from '@/components/FadeIn'
 import { GridPattern } from '@/components/GridPattern'
 import { PageIntro } from '@/components/PageIntro'
 import { formatDate } from '@/lib/formatDate'
+import { Badge } from '@/components/ui/badge'
 
 function Post({ article }) {
   return (
@@ -40,6 +41,22 @@ function Post({ article }) {
                 <div>{article.author.role}</div>
               </div>
             </dd>
+            {article.tags.length > 0 && (
+              <>
+                <dt className="sr-only">Tags</dt>
+                <dd className="mt-4 flex flex-wrap gap-2">
+                  {article.tags.map((tag) => (
+                    <Badge
+                      key={tag}
+                      variant="secondary"
+                      className="text-neutral-600"
+                    >
+                      {tag}
+                    </Badge>
+                  ))}
+                </dd>
+              </>
+            )}
           </dl>
           <p className="mt-6 max-w-2xl text-base text-neutral-600">
             {article.description}

--- a/src/app/blog/Pytorch-Internals/page.mdx
+++ b/src/app/blog/Pytorch-Internals/page.mdx
@@ -13,7 +13,7 @@ export const article = {
     color: '#2563eb',
   },
   image: { src: imageLaptop },
-  tags: ['pytorch', 'deep learning'],
+  tags: ['Written by human', 'Technical'],
 }
 
 export const metadata = {

--- a/src/app/blog/Transformers/page.mdx
+++ b/src/app/blog/Transformers/page.mdx
@@ -13,7 +13,7 @@ export const article = {
     color: '#2563eb',
   },
   image: { src: imageWhiteboard },
-  tags: ['transformers', 'deep learning'],
+  tags: ['Written by human', 'Technical'],
 }
 
 export const metadata = {

--- a/src/app/blog/gRPC-and-libtorch-with-Bazel/page.mdx
+++ b/src/app/blog/gRPC-and-libtorch-with-Bazel/page.mdx
@@ -13,7 +13,7 @@ export const article = {
     color: '#2563eb',
   },
   image: { src: imageWhiteboard },
-  tags: ['grpc', 'bazel', 'libtorch'],
+  tags: ['Written by human', 'Technical'],
 }
 
 export const metadata = {

--- a/src/app/blog/wrapper.jsx
+++ b/src/app/blog/wrapper.jsx
@@ -6,6 +6,7 @@ import { PageLinks } from '@/components/PageLinks'
 import { formatDate } from '@/lib/formatDate'
 import { loadArticles } from '@/lib/mdx'
 import 'katex/dist/katex.min.css'
+import { Badge } from '@/components/ui/badge'
 
 export default async function BlogArticleWrapper({ article, children }) {
   let allArticles = await loadArticles()
@@ -30,6 +31,19 @@ export default async function BlogArticleWrapper({ article, children }) {
             <p className="mt-6 text-sm font-semibold text-neutral-950">
               by {article.author.name}, {article.author.role}
             </p>
+            {article.tags.length > 0 && (
+              <div className="mt-4 flex flex-wrap justify-center gap-2">
+                {article.tags.map((tag) => (
+                  <Badge
+                    key={tag}
+                    variant="secondary"
+                    className="text-neutral-600"
+                  >
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            )}
           </header>
         </FadeIn>
 

--- a/src/app/blog/zsh-llm-config/page.mdx
+++ b/src/app/blog/zsh-llm-config/page.mdx
@@ -13,7 +13,7 @@ export const article = {
     color: '#2563eb',
   },
   image: { src: imageMeeting },
-  tags: ['zsh', 'llm', 'shell'],
+  tags: ['Written by human', 'Technical'],
 }
 
 export const metadata = {


### PR DESCRIPTION
## Summary
- show gray shadcn tags beneath authors on blog index
- add tag badges to individual blog article headers
- tag Noel's articles as "Written by human" and "Technical"

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af6a6edda0832c93216c134701c4e3